### PR TITLE
Add INSULIN_TYPE to run options.

### DIFF
--- a/bin/app.sh
+++ b/bin/app.sh
@@ -20,7 +20,7 @@ show_docker_usage () {
         docker run  -e NS_HOST=<ns_host> -e AUTOTUNE_DAYS=<autotune_days> -e UAM_AS_BASAL=<true|false> 
                     [-e NS_API_SECRET=<api_secret>] [-e NS_TOKEN=<token>] [-e NS_PROFILE=<profile_name>]
                     [-e MIN_5MIN_CARBIMPACT=<min_5m_carb_impact>] 
-                    [-e AUTOSENS_MIN=<autosens_min>] [-e AUTOSENS_MAX=<autosens_max>]
+                    [-e AUTOSENS_MIN=<autosens_min>] [-e AUTOSENS_MAX=<autosens_max>] [-e INSULIN_TYPE=<rapid-acting|ultra-rapid>]
     
     DESCRIPTION
         Run OpenAPS autotune against a Nightscout profile.
@@ -58,6 +58,9 @@ show_docker_usage () {
         -e AUTOSENS_MAX=<autosens_max>
             The multiplier for adjustments during insulin resistance. Defaults to 1.2 if omitted.
 
+        -e INSULIN_TYPE=<rapid-acting|ultra-rapid>
+            The type of insulin used to determine how fast is acts and decays. Defaults to 'rapid-acting' if omitted.
+
         -e OPENAPS_WORKDIR=<workdir>
             The working directory. Defaults to '/tmp/openaps' if omitted.
 
@@ -75,7 +78,8 @@ show_standalone_usage () {
         NS_HOST=<ns_host> AUTOTUNE_DAYS=<autotune_days> UAM_AS_BASAL=<true|false> 
         [NS_API_SECRET=<api_secret>] [NS_TOKEN=<token>] [NS_PROFILE=<profile_name>]
         [MIN_5MIN_CARBIMPACT=<min_5m_carb_impact>] 
-        [AUTOSENS_MIN=<autosens_min>] [AUTOSENS_MAX=<autosens_max>] $0 [help]
+        [AUTOSENS_MIN=<autosens_min>] [AUTOSENS_MAX=<autosens_max>] 
+        [INSULIN_TYPE=<rapid-acting|ultra-rapid>] $0 [help]
     
     DESCRIPTION
         Run OpenAPS autotune against a Nightscout profile.
@@ -115,6 +119,9 @@ show_standalone_usage () {
 
         AUTOSENS_MAX=<autosens_max>
             The multiplier for adjustments during insulin resistance. Defaults to 1.2 if omitted.
+        
+        INSULIN_TYPE=<rapid-acting|ultra-rapid>
+            The type of insulin used to determine how fast is acts and decays. Defaults to 'rapid-acting' if omitted.
 
         OPENAPS_WORKDIR=<workdir>
             The working directory. Defaults to '/tmp/openaps' if omitted.
@@ -143,7 +150,9 @@ elif [ -z "$NS_HOST" ] || [ -z "$AUTOTUNE_DAYS" ] || [ -z "$UAM_AS_BASAL" ]; the
     exit 1
 fi
 
-PROFILE_DATA=$(convert-ns-profile --ns-host $NS_HOST --api-secret $NS_API_SECRET --token $NS_TOKEN --profile $NS_PROFILE --min-5m-carb-impact $MIN_5MIN_CARBIMPACT --autosens-min $AUTOSENS_MIN --autosens-max $AUTOSENS_MAX)
+PROFILE_DATA=$(convert-ns-profile --ns-host $NS_HOST --api-secret $NS_API_SECRET --token $NS_TOKEN --profile $NS_PROFILE \
+    --min-5m-carb-impact $MIN_5MIN_CARBIMPACT --autosens-min $AUTOSENS_MIN --autosens-max $AUTOSENS_MAX \
+    --insulin-type $INSULIN_TYPE)
 
 # Prepare for autotune
 echo "Preparing oref0-autotune directory structure in ${OPENAPS_WORKDIR}..."

--- a/main.js
+++ b/main.js
@@ -2,10 +2,11 @@
 import cli_args from 'command-line-args';
 import cli_usage from 'command-line-usage';
 import { fetch_profile } from './src/fetch_profile.js';
-import { ns_to_oaps } from './src/profile_converter.js';
+import { ns_to_oaps, InsulinType } from './src/profile_converter.js';
 
 const AUTOSENS_MIN_DEFAULT = 0.7;
 const AUTOSENS_MAX_DEFAULT = 1.2;
+const INSULIN_TYPE_DEFAULT = InsulinType.RAPID;
 const MIN_5M_CARBIMPACT_DEFAULT = 8.0;
 
 const option_definitions = [
@@ -15,6 +16,7 @@ const option_definitions = [
     { name: 'profile', alias: 'p', type: String, description: 'The name of the profile to use. If omitted, the default profile is used.' },   
     { name: 'autosens-min', type: Number, defaultValue: AUTOSENS_MIN_DEFAULT, description: 'Multiplier for adjustments during insulin sensitivity. Defaults to 0.7 if omitted.' },
     { name: 'autosens-max', type: Number, defaultValue: AUTOSENS_MAX_DEFAULT, description: 'Multiplier for adjustments during insulin resistance. Defaults to 1.2 if omitted.' },
+    { name: 'insulin-type', alias: 'i', type: String, defaultValue: INSULIN_TYPE_DEFAULT, description: 'The type of insulin to derive how fast it acts and decays.'},
     { name: 'min-5m-carb-impact', alias: 'c', type: Number, defaultValue: MIN_5M_CARBIMPACT_DEFAULT, description: 'Minimum carb absorption in grams per 5 minutes. Defaults to 8.0 if omitted.' },
     { name: 'help', alias: 'h', type: String, description: 'Print usage instructions.' }
 ];
@@ -56,6 +58,7 @@ function print_usage() {
     } else {
         let autosens_min = options['autosens-min'] || AUTOSENS_MIN_DEFAULT;
         let autosens_max = options['autosens-max'] || AUTOSENS_MAX_DEFAULT;
+        let insulin_type = options['insulin-type'] || INSULIN_TYPE_DEFAULT;
         let min_5m_carbimpact = options['min-5m-carb-impact'] || MIN_5M_CARBIMPACT_DEFAULT;
         let ns_host = options['ns-host'];
         let api_secret = options['api-secret'] || undefined;
@@ -81,7 +84,7 @@ function print_usage() {
         
 
         let ns_profile = await fetch_profile(ns_host, api_secret, ns_token, profile);
-        let oaps_profile = ns_to_oaps(ns_profile, min_5m_carbimpact, autosens_min, autosens_max);
+        let oaps_profile = ns_to_oaps(ns_profile, min_5m_carbimpact, autosens_min, autosens_max, insulin_type);
         console.log(JSON.stringify(oaps_profile, null, 2));
     }
 })();

--- a/src/profile_converter.js
+++ b/src/profile_converter.js
@@ -1,5 +1,14 @@
 import { timeParse } from 'd3-time-format';
 
+/**
+ * The type of insulin in the profile.
+ * @typedef {('rapid-acting'|'ultra-rapid')} InsulinType
+ */
+export const InsulinType = {
+    RAPID: 'rapid-acting',
+    ULTRA_RAPID: 'ultra-rapid'
+}
+
 function normalize_ns_timed_element(element) {
     let time = {...element}
     if(time.timeAsSeconds === undefined) {
@@ -27,16 +36,18 @@ function normalize_ns_timed_element(element) {
  * @param {number} min_5m_carbimpact The minimal carbs absorption per 5 minutes.
  * @param {number} autosens_min The multiplier for adjustments during insulin sensitivity.
  * @param {number} autosens_max The multiplier for adjustments during insulin resistance.
+ * @param {InsulinType} curve The insulin type to infer how quickly it acts and decays.
  * @returns The OAPS profile.
  */
-export function ns_to_oaps(ns_profile, min_5m_carbimpact = 8.0, autosens_min = 0.7, autosens_max = 1.2) {
+export function ns_to_oaps(ns_profile, min_5m_carbimpact = 8.0, autosens_min = 0.7, autosens_max = 1.2, curve = InsulinType.RAPID) {
     let oaps_profile = {
         min_5m_carbimpact: min_5m_carbimpact,
         dia: ns_profile.dia,
         autosens_max: autosens_max,
         autosens_min: autosens_min,
         out_units: ns_profile.units,
-        timezone: ns_profile.timezone
+        timezone: ns_profile.timezone,
+        curve: curve
     };
 
     // Basal profile

--- a/tests/resources/oaps_profile.json
+++ b/tests/resources/oaps_profile.json
@@ -446,6 +446,7 @@
     ]
   },
   "min_5m_carbimpact": 8,
+  "curve": "rapid-acting",
   "out_units": "mmol",
   "timezone": "Europe/Amsterdam"
 }


### PR DESCRIPTION
This allows users to choose between rapid and ultra-rapid insulin, which allows autotune to determine how fast it acts and decays. The insulin type defaults to rapid.